### PR TITLE
refactor: add Partial to return type

### DIFF
--- a/src/07-challenges/35-form-validator.solution.ts
+++ b/src/07-challenges/35-form-validator.solution.ts
@@ -9,7 +9,7 @@ const makeFormValidatorFactory =
   <TInput extends ValidatorConfig<keyof TValidators>>(config: TInput) => {
     return (
       values: Record<keyof TInput, string>,
-    ): Record<keyof TInput, string | undefined> => {
+    ): Partial<Record<keyof TInput, string>> => {
       const errors = {} as any;
 
       for (const key in config) {


### PR DESCRIPTION
> #35-form-validator exercice

Small question / suggestion regarding the typing of the errors object: wouldn't it be better to return a partial object to make the autocomplete indicating the possible absence of the key? (It doesn't essentially change anything as in both cases the type `string | undefined `is returned.)

Without `Partial`: 
![image](https://user-images.githubusercontent.com/55456241/196703527-1d58f20e-f2ba-4d0e-b99c-484fed22a53d.png)

With `Partial`:
![image](https://user-images.githubusercontent.com/55456241/196703950-bc9e6735-a7d1-43a9-b585-5e48b7241e2f.png)


