### PR TITLE
Fixed vite.config.ts type error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
In `vite.config.ts`, I noticed
```ts
import { defineConfig } from 'vite'

export default defineConfig({
  test: { //  'test' does not exist in type 'UserConfigExport'.ts(2345)
    // ...
  },
})
```

After a little [bit of snooping around](https://vitest.dev/config/#configuration), I figured it was supposed to be imported from `vitest` not `vite`

```ts
import { defineConfig } from 'vitest/config'
```