### PR TITLE
fix s-34 solution screaming Argument of type '[]' is not assignable

### DIFF
--- a/src/06-challenges/34-internationalization.solution.ts
+++ b/src/06-challenges/34-internationalization.solution.ts
@@ -16,7 +16,9 @@ const translate = <
 >(
   translations: TTranslations,
   key: TKey,
-  ...args: TDynamicKeys extends string
+  ...args: [TDynamicKeys] extends [never] 
+    ? []
+    : TDynamicKeys extends string
     ? [dynamicArgs: Record<TDynamicKeys, string>]
     : []
 ) => {


### PR DESCRIPTION
# Description

Solution 34 - 34-internationalization.solution  line 38: Typescript is screaming
```javascript
  const buttonText = translate(translations, "button");
// Argument of type '[]' is not assignable to parameter of type 'never'.
// Translation: I was expecting never, but you passed []
```

```javascript
  ...args: TDynamicKeys extends string
    ? [dynamicArgs: Record<TDynamicKeys, string>]
    : []
```
Because `TDynamicKeys` (line 15) become `never`  in case of button property of transalations
causing `...args` to become type `never`

Fixes 

check if `TDynamicKeys` is type never first
```javascript
  ...args: [TDynamicKeys] extends [never] 
    ? []
    : TDynamicKeys extends string
    ? [dynamicArgs: Record<TDynamicKeys, string>]
    : []
```
## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

Because