### PR TITLE
Feature/#21: Remove disparity between the partial inference exercise and solution

### DIFF
--- a/src/04-generics-advanced/20.7-working-around-partial-inference.problem.ts
+++ b/src/04-generics-advanced/20.7-working-around-partial-inference.problem.ts
@@ -2,7 +2,7 @@ import { Equal, Expect } from "../helpers/type-utils";
 
 export const makeSelectors = <
   TSource,
-  TSelectors extends Record<string, (source: TSource) => any> = {},
+  TSelectors extends Record<string, (source: TSource) => any>,
 >(
   selectors: TSelectors,
 ) => {


### PR DESCRIPTION
PR for #21.

Firstly, thanks for creating this fantastic TypeScript content. I noticed this disparity between the exercise and the solution when working through the exercise; it didn't seem to be mentioned in the solution video, and I stumbled across a pre-existing issue (#21) so I've raised this pull request to address it. 

This pull request removes the default type argument from the selectors generic in the partial inference workshop. The default widens the type of the generic to `any` which could trip people up (and arguably/evidently has).

If this was intentionally left in place to manipulate the compiler errors to better make an example of the partial inference problem, then perhaps this issue can be closed, and the default argument mentioned/explained in the problem video and solution?

Thanks again for the amazing content as always Matt!

### Changes

- Remove the default type argument from the selectors generic.