### PR TITLE
feat: propose generic then method solution for passing-type-arguments 11

### DIFF
--- a/src/02-passing-type-arguments/11-data-fetcher.solution.ts
+++ b/src/02-passing-type-arguments/11-data-fetcher.solution.ts
@@ -2,7 +2,7 @@ import { expect, it } from "vitest";
 import { Equal, Expect } from "../helpers/type-utils";
 
 const fetchData = async <TData>(url: string) => {
-  let data: TData = await fetch(url).then((response) => response.json());
+  const data = await fetch(url).then<TData>((response) => response.json());
 
   return data;
 };


### PR DESCRIPTION
It is possible to enter a generic type argument for the `then` function.  This seems more intuitive to me than typing data.