### PR TITLE
Improved solution for 19

### DIFF
--- a/src/05-function-overloads/24-function-overloads-vs-union-types.problem.ts
+++ b/src/05-function-overloads/24-function-overloads-vs-union-types.problem.ts
@@ -8,7 +8,7 @@ function runGenerator(generator: unknown) {
   return generator.run();
 }
 
-it("Should accept an object where the generator is a function", () => {
+it("Should accept an object with a function run", () => {
   const result = runGenerator({
     run: () => "hello",
   });
@@ -18,7 +18,7 @@ it("Should accept an object where the generator is a function", () => {
   type test1 = Expect<Equal<typeof result, string>>;
 });
 
-it("Should accept an object where the generator is a function", () => {
+it("Should accept an argument where the generator is a function", () => {
   const result = runGenerator(() => "hello");
 
   expect(result).toBe("hello");

--- a/src/05-function-overloads/24-function-overloads-vs-union-types.solution.1.ts
+++ b/src/05-function-overloads/24-function-overloads-vs-union-types.solution.1.ts
@@ -10,7 +10,7 @@ function runGenerator(generator: { run: () => string } | (() => string)) {
   return generator.run();
 }
 
-it("Should accept an object where the generator is a function", () => {
+it("Should accept an object with a function run", () => {
   const result = runGenerator({
     run: () => "hello",
   });
@@ -20,7 +20,7 @@ it("Should accept an object where the generator is a function", () => {
   type test1 = Expect<Equal<typeof result, string>>;
 });
 
-it("Should accept an object where the generator is a function", () => {
+it("Should accept an argument where the generator is a function", () => {
   const result = runGenerator(() => "hello");
 
   expect(result).toBe("hello");

--- a/src/05-function-overloads/24-function-overloads-vs-union-types.solution.2.ts
+++ b/src/05-function-overloads/24-function-overloads-vs-union-types.solution.2.ts
@@ -8,7 +8,7 @@ function runGenerator(generator: { run: () => string } | (() => string)) {
   return generator.run();
 }
 
-it("Should accept an object where the generator is a function", () => {
+it("Should accept an object with a function run", () => {
   const result = runGenerator({
     run: () => "hello",
   });
@@ -18,7 +18,7 @@ it("Should accept an object where the generator is a function", () => {
   type test1 = Expect<Equal<typeof result, string>>;
 });
 
-it("Should accept an object where the generator is a function", () => {
+it("Should accept an argument where the generator is a function", () => {
   const result = runGenerator(() => "hello");
 
   expect(result).toBe("hello");


### PR DESCRIPTION
Got rid of any in the 19th exercise solution by replacing `Record<string, any>` with `Record<string, ReturnType<typeof transform>>`