### PR TITLE
Fix type constraint issue when explicitly specifying a third type parameter.

### DIFF
--- a/src/06-challenges/34-internationalization.solution.ts
+++ b/src/06-challenges/34-internationalization.solution.ts
@@ -9,7 +9,7 @@ type GetParamKeys<TTranslation extends string> = TTranslation extends ""
 const translate = <
   TTranslations extends Record<string, string>,
   TKey extends keyof TTranslations,
-  TParamKeys extends string[] = GetParamKeys<TTranslations[TKey]>,
+  TParamKeys extends GetParamKeys<TTranslations[TKey]>,
 >(
   translations: TTranslations,
   key: TKey,


### PR DESCRIPTION
Refined type parameter by replacing default array constraint with a direct dependency on `GetParamKeys<TTranslations[TKey]>` for improved accuracy and flexibility.