### PR TITLE
Update swapi.dev to swapi.info

### DIFF
--- a/src/02-passing-type-arguments/11-data-fetcher.problem.ts
+++ b/src/02-passing-type-arguments/11-data-fetcher.problem.ts
@@ -8,7 +8,7 @@ const fetchData = async (url: string) => {
 
 it("Should fetch data from an API", async () => {
   const data = await fetchData<{ name: string }>(
-    "https://swapi.dev/api/people/1",
+    "https://swapi.info/api/people/1",
   );
   expect(data.name).toEqual("Luke Skywalker");
 


### PR DESCRIPTION
A correct answer will fail the test because swapi.dev returns a 404 error.